### PR TITLE
hotfix/dropdown-chevron-flip

### DIFF
--- a/src/pages/market/market.component.tsx
+++ b/src/pages/market/market.component.tsx
@@ -9,13 +9,14 @@ const Market: FC = () => {
 	const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
 	const [sortField, setSortField] = useState<keyof ICoinData | null>(null);
 	const [rowsPerPage, setRowsPerPage] = useState(10);
+	const [dropdownOpen, setDropdownOpen] = useState(false);
 
 	const totalPages = Math.ceil(coinData.length / rowsPerPage);
 	const indexOfLastCoin = currentPage * rowsPerPage;
 	const indexOfFirstCoin = indexOfLastCoin - rowsPerPage;
 	const currentCoins = coinData.slice(indexOfFirstCoin, indexOfLastCoin);
 	const numOptions = [10, 20, 30, 40, 50];
-	const dropdownRef = useRef(null);
+	const dropdownRef = useRef<HTMLSelectElement | null>(null);
 
 	useEffect(() => {
 		const fetchCoinData = async () => {
@@ -41,16 +42,18 @@ const Market: FC = () => {
 		fetchCoinData();
 	}, []);
 
-	const handleNextPage = () => {
-		if (currentPage < 5) setCurrentPage(currentPage + 1);
+	const handleRowsChange = (event: any) => {
+		setRowsPerPage(event.target.value);
+		setCurrentPage(1);
 	};
 
-	const handlePreviousPage = () => {
-		if (currentPage > 1) setCurrentPage(currentPage - 1);
+	const toggleDropdown = (event: React.MouseEvent<HTMLSelectElement>) => {
+		event.stopPropagation();
+		setDropdownOpen(!dropdownOpen);
 	};
 
-	const handlePageClick = (pageNumber: number) => {
-		setCurrentPage(pageNumber);
+	const handleBlur = () => {
+		setDropdownOpen(false);
 	};
 
 	const handleSort = (field: keyof ICoinData | null) => {
@@ -76,9 +79,16 @@ const Market: FC = () => {
 		setCoinData(sortedData);
 	};
 
-	const handleRowsChange = (event: any) => {
-		setRowsPerPage(event.target.value);
-		setCurrentPage(1);
+	const handlePreviousPage = () => {
+		if (currentPage > 1) setCurrentPage(currentPage - 1);
+	};
+
+	const handlePageClick = (pageNumber: number) => {
+		setCurrentPage(pageNumber);
+	};
+
+	const handleNextPage = () => {
+		if (currentPage < 5) setCurrentPage(currentPage + 1);
 	};
 
 	return (
@@ -90,6 +100,8 @@ const Market: FC = () => {
 						className='rows-dropdown'
 						ref={dropdownRef}
 						onChange={handleRowsChange}
+						onClick={toggleDropdown}
+						onBlur={handleBlur}
 					>
 						{numOptions.map((num) => (
 							<option key={num} value={num}>
@@ -97,7 +109,8 @@ const Market: FC = () => {
 							</option>
 						))}
 					</select>
-					<span className='dropdown-arrow' />
+
+					<span className={`dropdown-arrow ${dropdownOpen ? 'flipped' : ''}`} />
 				</div>
 
 				<div className='table-container'>

--- a/src/pages/market/market.styles.scss
+++ b/src/pages/market/market.styles.scss
@@ -69,8 +69,14 @@
 				padding: 3px;
 				position: absolute;
 				right: 12px;
-				top: 30%;
-				transform: translateY(-50%) rotate(45deg);
+				top: 12px;
+				transform: rotate(45deg);
+				transition: transform 0.3s ease;
+
+				&.flipped {
+					top: 15px;
+					transform: rotate(-135deg);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description of Changes

This PR introduces an animation for the dropdown chevron. When a user interacts with the dropdown menu, the chevron smoothly flips to indicate the state of the dropdown (open or closed). Additional styles have been applied to ensure the chevron maintains its intended position during the animation.

## Type of Change

- [x] New Feature

## Describe the problem this PR solves and your solution.

Previously, there was no indication on the UI when a dropdown was expanded or collapsed. To enhance the user experience and provide clearer visual cues, a flip animation was added to the dropdown chevron.

## Testing Steps

1. Navigate to `Market` section with a dropdown menu.
2. Click on the dropdown menu to open it.
3. Observe the chevron flipping upward to indicate the dropdown is open.
4. Click on the dropdown menu again to close it.
5. Observe the chevron flipping downward to indicate the dropdown is closed.

## Screenshots

N/A

## Checklist

- [x] My code follows the code style of this project
- [x] This PR doesn't include breaking changes
- [x] Manual tests have been completed
- [x] Line in CHANGELOG.md has been added
- [x] Logs etc. have been removed
- [x] Testing steps have been added for the reviewer
