### PR TITLE
feature/add-fag-colour-guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # WIP
 
--
+- Added colour guide for the Fear and Greed index
 
 # v1.1.2 - 18th November 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 - Added colour guide for the Fear and Greed index
 
+# v1.1.3 - 24th March 2024
+
+- Added the following dependencies resolving application vulnerabilities:
+  - nth-check
+  - webpack-dev-middleware
+
 # v1.1.2 - 18th November 2023
 
 - Fixed active navbar link colour issue

--- a/src/components/fear-greed-index/fear-greed-index.component.tsx
+++ b/src/components/fear-greed-index/fear-greed-index.component.tsx
@@ -83,7 +83,26 @@ const FearGreedIndex = () => {
 				<p>{data?.value_classification}</p>
 			</div>
 			{countDown !== null && <div>Next update in: {timeInHMS(countDown)}</div>}
-			<br></br>
+			<div className='color-guide-container'>
+				<div className='color-guide'>
+					<div>
+						<span className='color-box extreme-fear-box'></span>Extreme Fear
+					</div>
+					<div>
+						<span className='color-box fear-box'></span>Fear
+					</div>
+					<div>
+						<span className='color-box neutral-box'></span>Neutral
+					</div>
+					<div>
+						<span className='color-box greed-box'></span>Greed
+					</div>
+					<div>
+						<span className='color-box extreme-greed-box'></span>Extreme Greed
+					</div>
+				</div>
+			</div>
+			<br />
 			<Footer />
 		</div>
 	);

--- a/src/components/fear-greed-index/fear-greed-index.styles.scss
+++ b/src/components/fear-greed-index/fear-greed-index.styles.scss
@@ -38,6 +38,53 @@
 	background-color: #16c784;
 }
 
+.color-guide-container {
+	margin-top: 20px;
+}
+
+.color-guide {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin-top: 10px;
+	font-size: 14px;
+}
+
+.color-box {
+	width: 20px;
+	height: 20px;
+	display: inline-block;
+	margin-right: 8px;
+	border-radius: 2px;
+	border: 1px solid black;
+}
+
+.extreme-fear-box {
+	background-color: #ea3943;
+}
+
+.fear-box {
+	background-color: #ea8c00;
+}
+
+.neutral-box {
+	background-color: #f3d42f;
+}
+
+.greed-box {
+	background-color: #93d900;
+}
+
+.extreme-greed-box {
+	background-color: #16c784;
+}
+
+.color-guide div {
+	display: flex;
+	align-items: center;
+	margin: 0 12px;
+}
+
 .tooltip {
 	cursor: pointer;
 	display: inline-block;

--- a/src/components/fear-greed-index/fear-greed-index.styles.scss
+++ b/src/components/fear-greed-index/fear-greed-index.styles.scss
@@ -1,3 +1,9 @@
+$extreme-fear-colour: #ea3943;
+$fear-colour: #ea8c00;
+$neutral-colour: #f3d42f;
+$greed-colour: #93d900;
+$extreme-greed-colour: #16c784;
+
 .fear-greed-index {
 	align-items: center;
 	border-radius: 8px 8px 0 0;
@@ -19,23 +25,23 @@
 }
 
 .fear-greed-index.Extreme-Fear {
-	background-color: #ea3943;
+	background-color: $extreme-fear-colour;
 }
 
 .fear-greed-index.Fear {
-	background-color: #ea8c00;
+	background-color: $fear-colour;
 }
 
 .fear-greed-index.Neutral {
-	background-color: #f3d42f;
+	background-color: $neutral-colour;
 }
 
 .fear-greed-index.Greed {
-	background-color: #93d900;
+	background-color: $greed-colour;
 }
 
 .fear-greed-index.Extreme-Greed {
-	background-color: #16c784;
+	background-color: $extreme-greed-colour;
 }
 
 .color-guide-container {
@@ -60,23 +66,23 @@
 }
 
 .extreme-fear-box {
-	background-color: #ea3943;
+	background-color: $extreme-fear-colour;
 }
 
 .fear-box {
-	background-color: #ea8c00;
+	background-color: $fear-colour;
 }
 
 .neutral-box {
-	background-color: #f3d42f;
+	background-color: $neutral-colour;
 }
 
 .greed-box {
-	background-color: #93d900;
+	background-color: $greed-colour;
 }
 
 .extreme-greed-box {
-	background-color: #16c784;
+	background-color: $extreme-greed-colour;
 }
 
 .color-guide div {


### PR DESCRIPTION
## Description of Changes

This PR introduces a colour guide for the FAG index at the footer of the app, and updates the colour references to use SCSS variables. This change eliminates duplicate colour definitions by defining reusable colour variables. This improves maintainability and consistency in the styling of the "Fear and Greed" index.

## Type of Change

- [x] New Feature

## Testing Steps

1. Verify that the "Fear and Greed" index sections display the correct background colours as defined by the SCSS variables.
2. Check the footer of the app to ensure the colour guide is displayed correctly with the respective colours.
3. Ensure there are no visual discrepancies or broken styles in the UI after the change.

## Screenshots

<img width="1800" alt="Screenshot 2024-08-04 at 21 41 19" src="https://github.com/user-attachments/assets/41afbe01-6118-4237-b156-8871fa6ff546">

## Checklist

_Tick once complete_

- [x] My code follows the code style of this project
- [x] This PR doesn't include breaking changes
- [x] Manual tests have been completed
- [x] Line in CHANGELOG.md has been added
- [x] Logs etc. have been removed
- [x] Testing steps have been added for the reviewer