### PR TITLE
hotfix/fag-colour-guide-box-mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 # WIP
 
-- Added colour guide for the Fear and Greed index
-
-# v1.1.3 - 24th March 2024
-
-- Added the following dependencies resolving application vulnerabilities:
-  - nth-check
-  - webpack-dev-middleware
+- Hide colour guide when on mobile device
 
 # v1.1.4 - 8th August 2024
 

--- a/src/components/fear-greed-index/fear-greed-index.styles.scss
+++ b/src/components/fear-greed-index/fear-greed-index.styles.scss
@@ -128,7 +128,7 @@ $extreme-greed-colour: #16c784;
 	padding: 5px 0;
 	position: absolute;
 	text-align: center;
-	transition: opacity 0.3s;
+	transition: opacity 0.3s, visibility 0.3s;
 	visibility: hidden;
 	width: 300px;
 	z-index: 1;
@@ -146,6 +146,10 @@ $extreme-greed-colour: #16c784;
 }
 
 @media screen and (max-width: 600px) {
+	.color-guide-container {
+		display: none;
+	}
+
 	.tooltiptext {
 		font-size: 12px;
 		padding: 4px 0;


### PR DESCRIPTION
## Description of Changes

This update removes the colour guide on mobile devices to improve the user experience and make the layout cleaner for smaller screens. The colour guide will now only be visible on larger screens (above 600px). The colour guide section will automatically hide on screens below this width.

## Type of Change

Please select the relevant option by adding `x` inside the bracket e.g. '[x]'. 

- [x] New Feature

## Describe the problem this PR solves and your solution.

Previously, the colour guide would take up too much space on mobile devices, making the layout feel crowded. To resolve this, the colour guide has been hidden on screens smaller than 600px while retaining its display on larger screens.

## Testing Steps

_Please include what steps should be followed to test this new feature/recreate the problem that this PR fixes:_

1. View the component on a desktop screen (above 600px) and verify that the colour guide is visible.
2. View the component on a mobile screen (below 600px) and verify that the colour guide is hidden.
3. Ensure the rest of the component functions as expected across both desktop and mobile views.

## Checklist

_Tick once complete_

- [x] My code follows the code style of this project
- [x] This PR doesn't include breaking changes
- [x] Manual tests have been completed
- [x] Line in CHANGELOG.md has been added
- [x] Logs etc. have been removed
- [x] Testing steps have been added for the reviewer