### PR TITLE
fix/mobile-token-scroll-menu-icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Fixed mobile token navigation, home scroll restoration, and market row activation
+- Fixed mobile navbar icon colours and active-section highlighting
+
 # v1.3.0 - 19th June 2026
 
 - Migrated the project from Create React App to Vite and removed unused dependencies to reduce audit noise and package footprint

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ function AppContent() {
 						<Topbar />
 						<Navbar />
 						<Routes>
-							<Route path='/:name' element={<CryptoDetail />} />
+							<Route path='/:coinId' element={<CryptoDetail />} />
 							<Route
 								path='/'
 								element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.scss';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import {
 	BrowserRouter as Router,
 	Route,
@@ -19,6 +19,20 @@ import CoinGeckoProvider from './contexts/coingecko-context';
 import AppLoadingGate from './components/app-loading-gate/app-loading-gate.component';
 import AppErrorBoundary from './components/app-error-boundary/app-error-boundary.component';
 
+const RouteScrollHandler: React.FC<{ position: number }> = ({ position }) => {
+	const location = useLocation();
+
+	useLayoutEffect(() => {
+		window.scrollTo({
+			top: location.pathname === '/' ? position : 0,
+			left: 0,
+			behavior: 'auto',
+		});
+	}, [location.pathname, position]);
+
+	return null;
+};
+
 function AppContent() {
 	const location = useLocation();
 	const [marketRowsPerPage, setMarketRowsPerPage] = useState(10);
@@ -26,15 +40,24 @@ function AppContent() {
 	const [position, setPosition] = useState(0);
 
 	useEffect(() => {
-		if (location.pathname === '/') {
-			window.scrollTo(0, position);
+		const currentScrollRestoration = window.history.scrollRestoration;
+
+		if ('scrollRestoration' in window.history) {
+			window.history.scrollRestoration = 'manual';
 		}
-	}, [location.pathname, position]);
+
+		return () => {
+			if ('scrollRestoration' in window.history) {
+				window.history.scrollRestoration = currentScrollRestoration;
+			}
+		};
+	}, []);
 
 	return (
 		<ScrollPositionContext.Provider value={{ position, setPosition }}>
 			<AppErrorBoundary resetKey={`${location.pathname}${location.search}`}>
 				<AppLoadingGate>
+					<RouteScrollHandler position={position} />
 					<div className='App'>
 						<Topbar />
 						<Navbar />

--- a/src/components/coinrow/coinrow.component.tsx
+++ b/src/components/coinrow/coinrow.component.tsx
@@ -49,7 +49,13 @@ const CoinRow: FC<ICoinData> = ({
 	};
 
 	const handleRowKeyDown = (event: React.KeyboardEvent<HTMLTableRowElement>) => {
-		if (event.key !== 'Enter' && event.key !== ' ') {
+		const isActivationKey =
+			event.key === 'Enter' ||
+			event.key === ' ' ||
+			event.key === 'Spacebar' ||
+			event.code === 'Space';
+
+		if (!isActivationKey) {
 			return;
 		}
 

--- a/src/components/coinrow/coinrow.component.tsx
+++ b/src/components/coinrow/coinrow.component.tsx
@@ -37,15 +37,24 @@ const CoinRow: FC<ICoinData> = ({
 
 	const { setPosition } = useScrollPosition();
 
-	const navigateToDetail = (rowsPerPage: number, currentPage: number) => {
+	const navigateToDetail = () => {
+		setPosition(window.scrollY);
 		navigate(`/${id}`, {
 			state: { fromMarket: true, rowsPerPage, currentPage },
 		});
 	};
 
 	const handleRowClick = () => {
-		setPosition(window.scrollY);
-		navigateToDetail(rowsPerPage, currentPage);
+		navigateToDetail();
+	};
+
+	const handleRowKeyDown = (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+		if (event.key !== 'Enter' && event.key !== ' ') {
+			return;
+		}
+
+		event.preventDefault();
+		navigateToDetail();
 	};
 
 	return (
@@ -54,9 +63,8 @@ const CoinRow: FC<ICoinData> = ({
 			onClick={handleRowClick}
 			role='button'
 			tabIndex={0}
-			onKeyDown={(e) =>
-				e.key === 'Enter' && navigateToDetail(rowsPerPage, currentPage)
-			}
+			aria-label={`View ${name} details`}
+			onKeyDown={handleRowKeyDown}
 		>
 			<td>{rank}</td>
 			<td>

--- a/src/components/crypto-detail/crypto-detail.component.tsx
+++ b/src/components/crypto-detail/crypto-detail.component.tsx
@@ -20,8 +20,9 @@ import {
 
 const CryptoDetail: FC = () => {
 	const navigate = useNavigate();
-	const { name } = useParams<{ name?: string }>();
-	const coinUrl = name ? getCoinDetailUrl(name.toLowerCase()) : null;
+	const { coinId } = useParams<{ coinId?: string }>();
+	const normalizedCoinId = coinId?.toLowerCase();
+	const coinUrl = normalizedCoinId ? getCoinDetailUrl(normalizedCoinId) : null;
 
 	const [coinDetail, setCoinDetail] = useState<CoinDetail | null>(
 		() => (coinUrl ? getCachedData<CoinDetail>(coinUrl) : null),
@@ -32,7 +33,7 @@ const CryptoDetail: FC = () => {
 	useEffect(() => {
 		let isMounted = true;
 
-		if (name && name === name.toLowerCase()) {
+		if (coinId && normalizedCoinId && coinId === normalizedCoinId) {
 			const cachedCoinDetail = coinUrl
 				? getCachedData<CoinDetail>(coinUrl)
 				: null;
@@ -41,7 +42,7 @@ const CryptoDetail: FC = () => {
 			setLoading(!cachedCoinDetail);
 			setError(null);
 
-			getCachedJson<CoinDetail>(getCoinDetailUrl(name), {
+			getCachedJson<CoinDetail>(getCoinDetailUrl(normalizedCoinId), {
 				ttlMs: COIN_DETAIL_TTL_MS,
 			})
 				.then((data) => {
@@ -67,14 +68,14 @@ const CryptoDetail: FC = () => {
 		return () => {
 			isMounted = false;
 		};
-	}, [coinUrl, name]);
+	}, [coinId, coinUrl, normalizedCoinId]);
 
-	if (!name) {
-		return <div>Error: Name not provided.</div>;
+	if (!coinId) {
+		return <div>Error: Coin id not provided.</div>;
 	}
 
-	if (name !== name.toLowerCase()) {
-		navigate(`/${name.toLowerCase()}`);
+	if (coinId !== normalizedCoinId) {
+		navigate(`/${normalizedCoinId}`);
 		return null;
 	}
 

--- a/src/components/navbar/navbar.component.tsx
+++ b/src/components/navbar/navbar.component.tsx
@@ -4,7 +4,6 @@ import React, { FC, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Link as RouterLink } from 'react-router-dom';
 import { Link as ScrollLink } from 'react-scroll';
-import { useScrollPosition } from '../../contexts/scroll-position-context';
 import { MdMenu, MdClose } from 'react-icons/md';
 
 const links = ['home', 'market', 'learn', 'social'];
@@ -17,16 +16,69 @@ const Navbar: FC = () => {
 	const [activeLink, setActiveLink] = useState('home');
 
 	useEffect(() => {
-		setActiveLink('home');
-	}, []);
-
-	const { position } = useScrollPosition();
-
-	const handleNameClick = () => {
 		if (isDetailPage) {
-			window.scrollTo(0, position);
+			setMenuOpen(false);
 		}
-	};
+	}, [isDetailPage]);
+
+	useEffect(() => {
+		if (isDetailPage) {
+			return;
+		}
+
+		let animationFrameId = 0;
+		const stickyHeaderOffset = 120;
+
+		const updateActiveLink = () => {
+			const currentLink =
+				links.find((link) => {
+					const sectionElement = document.getElementById(link);
+
+					if (!sectionElement) {
+						return false;
+					}
+
+					const sectionBounds = sectionElement.getBoundingClientRect();
+
+					return (
+						sectionBounds.top <= stickyHeaderOffset &&
+						sectionBounds.bottom > stickyHeaderOffset
+					);
+				}) ??
+				links.reduce((activeSection, link) => {
+					const sectionElement = document.getElementById(link);
+
+					if (!sectionElement) {
+						return activeSection;
+					}
+
+					const sectionBounds = sectionElement.getBoundingClientRect();
+
+					return sectionBounds.top <= stickyHeaderOffset
+						? link
+						: activeSection;
+				}, 'home');
+
+			setActiveLink(currentLink);
+		};
+
+		const scheduleActiveLinkUpdate = () => {
+			window.cancelAnimationFrame(animationFrameId);
+			animationFrameId = window.requestAnimationFrame(updateActiveLink);
+		};
+
+		scheduleActiveLinkUpdate();
+		window.addEventListener('scroll', scheduleActiveLinkUpdate, {
+			passive: true,
+		});
+		window.addEventListener('resize', scheduleActiveLinkUpdate);
+
+		return () => {
+			window.cancelAnimationFrame(animationFrameId);
+			window.removeEventListener('scroll', scheduleActiveLinkUpdate);
+			window.removeEventListener('resize', scheduleActiveLinkUpdate);
+		};
+	}, [isDetailPage]);
 
 	const toggleMenu = () => {
 		setMenuOpen(!menuOpen);
@@ -35,7 +87,7 @@ const Navbar: FC = () => {
 	if (isDetailPage) {
 		return (
 			<nav className='navbar-container'>
-				<div className='navbar-name' onClick={handleNameClick}>
+				<div className='navbar-name'>
 					<RouterLink to='/' className='navbar-name-link'>
 						{' '}
 						<b>CoinPulse</b>
@@ -58,43 +110,52 @@ const Navbar: FC = () => {
 					<b>CoinPulse</b>
 				</ScrollLink>
 			</div>
-			<button onClick={toggleMenu} className='menu-button'>
-				<MdMenu size={32} />
+			<button
+				type='button'
+				onClick={toggleMenu}
+				className='menu-button'
+				aria-label='Open navigation menu'
+				aria-expanded={menuOpen}
+				aria-controls='mobile-navigation'
+			>
+				<MdMenu size={32} aria-hidden='true' />
 			</button>
 			<div className='navbar-links'>
 				{links.map((link) => (
 					<ScrollLink
 						key={link}
 						className={link === activeLink ? 'active' : ''}
-						activeClass='active'
 						to={link}
-						spy={true}
 						smooth={true}
 						offset={-70}
 						duration={500}
-						onSetActive={() => setActiveLink(link)}
 					>
 						{link.charAt(0).toUpperCase() + link.slice(1)}
 					</ScrollLink>
 				))}
 			</div>
-			<div className={`mobile-menu ${menuOpen ? 'open' : ''}`}>
+			<div
+				id='mobile-navigation'
+				className={`mobile-menu ${menuOpen ? 'open' : ''}`}
+			>
 				{menuOpen && (
 					<>
-						<button onClick={toggleMenu} className='close-button'>
-							<MdClose size={32} />
+						<button
+							type='button'
+							onClick={toggleMenu}
+							className='close-button'
+							aria-label='Close navigation menu'
+						>
+							<MdClose size={32} aria-hidden='true' />
 						</button>
 						{links.map((link) => (
 							<ScrollLink
 								key={link}
 								className={link === activeLink ? 'active' : ''}
-								activeClass='active'
 								to={link}
-								spy={true}
 								smooth={true}
 								offset={-70}
 								duration={500}
-								onSetActive={() => setActiveLink(link)}
 								onClick={toggleMenu}
 							>
 								{link.charAt(0).toUpperCase() + link.slice(1)}

--- a/src/components/navbar/navbar.component.tsx
+++ b/src/components/navbar/navbar.component.tsx
@@ -7,6 +7,17 @@ import { Link as ScrollLink } from 'react-scroll';
 import { MdMenu, MdClose } from 'react-icons/md';
 
 const links = ['home', 'market', 'learn', 'social'];
+const FALLBACK_STICKY_HEADER_OFFSET = 120;
+
+const getStickyHeaderOffset = () => {
+	const navbarElement = document.querySelector<HTMLElement>('.navbar-container');
+
+	if (!navbarElement) {
+		return FALLBACK_STICKY_HEADER_OFFSET;
+	}
+
+	return navbarElement.getBoundingClientRect().bottom;
+};
 
 const Navbar: FC = () => {
 	const location = useLocation();
@@ -27,9 +38,9 @@ const Navbar: FC = () => {
 		}
 
 		let animationFrameId = 0;
-		const stickyHeaderOffset = 120;
 
 		const updateActiveLink = () => {
+			const stickyHeaderOffset = getStickyHeaderOffset();
 			const currentLink =
 				links.find((link) => {
 					const sectionElement = document.getElementById(link);

--- a/src/components/navbar/navbar.styles.scss
+++ b/src/components/navbar/navbar.styles.scss
@@ -49,29 +49,52 @@
 }
 
 .menu-button {
+	-webkit-appearance: none;
+	-webkit-tap-highlight-color: transparent;
+	appearance: none;
 	background-color: transparent;
 	border: none;
+	color: $primary-color;
 	cursor: pointer;
 	display: none;
+	line-height: 0;
 	transition: color 0.3s ease-in-out;
 	margin-left: auto;
 
-	&:hover {
+	svg {
+		color: currentColor;
+		fill: currentColor;
+	}
+
+	&:hover,
+	&:focus-visible,
+	&:active {
 		color: $secondary-color;
 	}
 }
 
 .close-button {
+	-webkit-appearance: none;
+	-webkit-tap-highlight-color: transparent;
+	appearance: none;
 	background: transparent;
 	border: none;
 	color: $primary-color;
 	cursor: pointer;
+	line-height: 0;
 	position: absolute;
 	right: 1rem;
 	top: 3.5rem;
 	transition: color 0.3s ease-in-out;
 
-	&:hover {
+	svg {
+		color: currentColor;
+		fill: currentColor;
+	}
+
+	&:hover,
+	&:focus-visible,
+	&:active {
 		color: $secondary-color;
 	}
 }

--- a/src/pages/home/home.component.tsx
+++ b/src/pages/home/home.component.tsx
@@ -22,9 +22,9 @@ const Home: FC = () => {
 
 	const { coinData, errorMessage } = context;
 
-	const handleCoinClick = (name: string) => {
+	const handleCoinClick = (id: string) => {
 		setPosition(window.scrollY);
-		navigate(`/${name.toLowerCase()}`);
+		navigate(`/${id}`);
 	};
 
 	return (
@@ -40,7 +40,7 @@ const Home: FC = () => {
 							<div
 								key={coin.id}
 								className='coin-item'
-								onClick={() => handleCoinClick(coin.name)}
+								onClick={() => handleCoinClick(coin.id)}
 							>
 								<img src={coin.image} alt={coin.name} className='coin-image' />
 								<h2>{coin.name}</h2>


### PR DESCRIPTION
## Description of Changes

This PR improves mobile navigation and token detail navigation behavior.

Changes include:
- Token detail pages now always open from the top of the page.
- Returning to the home page restores the previous scroll position.
- Market table row click and keyboard navigation now share the same detail navigation behavior.
- Mobile hamburger and close icons now force the intended app colors on iOS.
- Navbar active state now reflects the section currently under the sticky header after scrolling or returning from a token page.
- Home token cards now navigate by coin id for consistency with the market table.

No new dependencies are required.

## Type of Change

- [x] Bug Fix

## Describe the problem this PR solves and your solution.

- Mobile token navigation could preserve the previous scroll offset when opening a token detail page, causing detail pages to load partway down the page. The route scroll handling now restores home scroll position only on `/` and scrolls detail routes to the top.
- Returning from a token page could highlight the wrong navbar item. The navbar now calculates the active section from the viewport instead of relying on `react-scroll` spy state.
- iOS could render the hamburger/close icon controls with unintended blue styling. The icon buttons now explicitly use app colors and remove native mobile button styling.
- Table row keyboard activation did not fully match click behavior. Click, `Enter`, and `Space` now use the same navigation path.

## Testing Steps

_Please include what steps should be followed to test this new feature/recreate the problem that this PR fixes?_

- Run `npm run build`.
- Open the app on a mobile viewport.
- Scroll to the market section and select a token.
- Confirm the token detail page starts at the top.
- Navigate back to the home page.
- Confirm the previous scroll position is restored.
- Confirm the correct navbar section is highlighted after returning.
- Open the mobile menu and confirm the hamburger/close icons use the intended colors.
- Select a market table row with click, `Enter`, and `Space` and confirm each opens the token detail page.

## Screenshots

N/A

## Checklist

_Tick once complete_

- [x] My code follows the code style of this project
- [x] This PR doesn't include breaking changes
- [x] Manual tests have been completed
- [x] Line in CHANGELOG.md has been added
- [x] Logs etc. have been removed
- [x] Testing steps have been added for the reviewer