### PR TITLE
fix/global-loader-mobile-scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+# Unreleased
+
+- Improved token detail scroll resets so mobile detail pages reliably start at the top
+- Fixed global loader positioning so it remains centred and non-scrollable across mobile viewports
+
 # v1.3.1 - 20th June 2026
 
 - Fixed mobile token navigation, home scroll restoration, and market row activation
 - Fixed mobile navbar icon colours and active-section highlighting
 - Clarified the loading error message for public API rate limits
-- Fixed global loader positioning so it remains centered and non-scrollable on small viewports
 
 # v1.3.0 - 19th June 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed mobile token navigation, home scroll restoration, and market row activation
 - Fixed mobile navbar icon colours and active-section highlighting
 - Clarified the loading error message for public API rate limits
+- Fixed global loader positioning so it remains centered and non-scrollable on small viewports
 
 # v1.3.0 - 19th June 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - Improved token detail scroll resets so mobile detail pages reliably start at the top
-- Fixed global loader positioning so it remains centred and non-scrollable across mobile viewports
+- Fixed global loader positioning and scroll locking across mobile viewports
 
 # v1.3.1 - 20th June 2026
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -13,11 +13,12 @@
 	display: flex;
 	inset: 0;
 	justify-content: center;
-	overflow: hidden;
-	overscroll-behavior: none;
+	overflow-x: hidden;
+	overflow-y: auto;
+	overscroll-behavior: contain;
 	padding: 24px;
 	position: fixed;
-	touch-action: none;
+	touch-action: pan-y;
 	width: 100%;
 	z-index: 999;
 }
@@ -27,6 +28,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 18px;
+	margin: auto;
 	max-width: 420px;
 	text-align: center;
 	width: 100%;

--- a/src/App.scss
+++ b/src/App.scss
@@ -8,13 +8,17 @@
 .app-loading-screen {
 	align-items: center;
 	background: $background-primary;
+	box-sizing: border-box;
 	color: $primary-text-color;
 	display: flex;
+	inset: 0;
 	justify-content: center;
-	min-height: 100svh;
-	min-height: 100vh;
 	overflow: hidden;
+	overscroll-behavior: none;
 	padding: 24px;
+	position: fixed;
+	width: 100%;
+	z-index: 999;
 }
 
 .app-loading-panel {

--- a/src/App.scss
+++ b/src/App.scss
@@ -17,6 +17,7 @@
 	overscroll-behavior: none;
 	padding: 24px;
 	position: fixed;
+	touch-action: none;
 	width: 100%;
 	z-index: 999;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,11 +23,35 @@ const RouteScrollHandler: React.FC<{ position: number }> = ({ position }) => {
 	const location = useLocation();
 
 	useLayoutEffect(() => {
-		window.scrollTo({
-			top: location.pathname === '/' ? position : 0,
-			left: 0,
-			behavior: 'auto',
+		let secondAnimationFrameId = 0;
+		const targetPosition = location.pathname === '/' ? position : 0;
+		const scrollToTargetPosition = () => {
+			window.scrollTo({
+				top: targetPosition,
+				left: 0,
+				behavior: 'auto',
+			});
+
+			document.documentElement.scrollTop = targetPosition;
+			document.body.scrollTop = targetPosition;
+		};
+
+		scrollToTargetPosition();
+
+		// iOS Safari can adjust scroll after navigation/layout, so repeat the target scroll briefly.
+		const firstAnimationFrameId = window.requestAnimationFrame(() => {
+			scrollToTargetPosition();
+			secondAnimationFrameId = window.requestAnimationFrame(
+				scrollToTargetPosition,
+			);
 		});
+		const timeoutId = window.setTimeout(scrollToTargetPosition, 100);
+
+		return () => {
+			window.cancelAnimationFrame(firstAnimationFrameId);
+			window.cancelAnimationFrame(secondAnimationFrameId);
+			window.clearTimeout(timeoutId);
+		};
 	}, [location.pathname, position]);
 
 	return null;

--- a/src/components/app-loading-gate/app-loading-gate.component.tsx
+++ b/src/components/app-loading-gate/app-loading-gate.component.tsx
@@ -118,9 +118,10 @@ const AppLoadingGate: FC<AppLoadingGateProps> = ({ children }) => {
 	const forcedLoadingPreview =
 		loaderPreview === 'true' || loaderPreview === 'loading';
 	const forcedErrorPreview = loaderPreview === 'error';
+	const isAppLoading = state !== 'ready';
 
 	useEffect(() => {
-		if (state === 'ready') {
+		if (!isAppLoading) {
 			return;
 		}
 
@@ -134,7 +135,7 @@ const AppLoadingGate: FC<AppLoadingGateProps> = ({ children }) => {
 			document.body.style.overflow = previousBodyOverflow;
 			document.documentElement.style.overflow = previousDocumentOverflow;
 		};
-	}, [state]);
+	}, [isAppLoading]);
 
 	useEffect(() => {
 		let isMounted = true;

--- a/src/components/app-loading-gate/app-loading-gate.component.tsx
+++ b/src/components/app-loading-gate/app-loading-gate.component.tsx
@@ -120,6 +120,23 @@ const AppLoadingGate: FC<AppLoadingGateProps> = ({ children }) => {
 	const forcedErrorPreview = loaderPreview === 'error';
 
 	useEffect(() => {
+		if (state === 'ready') {
+			return;
+		}
+
+		const previousBodyOverflow = document.body.style.overflow;
+		const previousDocumentOverflow = document.documentElement.style.overflow;
+
+		document.body.style.overflow = 'hidden';
+		document.documentElement.style.overflow = 'hidden';
+
+		return () => {
+			document.body.style.overflow = previousBodyOverflow;
+			document.documentElement.style.overflow = previousDocumentOverflow;
+		};
+	}, [state]);
+
+	useEffect(() => {
 		let isMounted = true;
 		const startedAt = Date.now();
 


### PR DESCRIPTION
## Description of Changes

Fixed mobile viewport issues around the global loader and token detail navigation.

Changes include:
- Global loader now stays fixed and centred in the viewport.
- Page scrolling is disabled while the loader or loader error state is visible.
- Loader overlay prevents touch panning on mobile.
- Token detail route scroll restoration is more defensive for iOS/Safari timing quirks.

## Type of Change

- [x] Bug Fix

## Describe the problem this PR solves and your solution.

- On smaller viewports, the global loader could be scrolled, causing the loading UI to move around instead of staying centered.
- On some mobile devices, especially iOS, token detail pages could occasionally fail to start at the top after tapping a table row.
- This PR fixes the loader by using a fixed viewport overlay and locking document scroll while the loader is visible.
- This PR also repeats route scroll restoration briefly after navigation to account for mobile Safari scroll/layout timing.

## Testing Steps

_Please include what steps should be followed to test this new feature/recreate the problem that this PR fixes?_

- Run `npm run build`.
- Start the app locally.
- Open the app in a small mobile viewport.
- Use `?loader=true` and confirm the loader remains centered and cannot be scrolled.
- Use `?loader=error` and confirm the error loader remains centered and cannot be scrolled.
- Scroll down the market table on mobile Safari/iOS.
- Tap a token row.
- Confirm the token detail page consistently starts at the top.
- Navigate back and confirm the home page restores the previous scroll position.

## Screenshots

_Add any images that will help this PR to be reviewed_

- N/A

## Checklist

_Tick once complete_

- [x] My code follows the code style of this project
- [x] This PR doesn't include breaking changes
- [x] Manual tests have been completed
- [x] Line in CHANGELOG.md has been added
- [x] Logs etc. have been removed
- [x] Testing steps have been added for the reviewer